### PR TITLE
docs: recolor README badges to app accent (#805a96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>A clean desktop app for batch renaming and converting images - fast, safe filenames, and predictable results.</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  

--- a/README/README-IC-CN.md
+++ b/README/README-IC-CN.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>一款简洁的桌面应用，用于批量重命名和转换图片——快速、安全的文件名，以及可预期的结果。</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  

--- a/README/README-IC-DE.md
+++ b/README/README-IC-DE.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>Eine übersichtliche Desktop-App zum massenhaften Umbenennen und Konvertieren von Bildern - schnell, sichere Dateinamen und vorhersehbare Ergebnisse.</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  

--- a/README/README-IC-EN.md
+++ b/README/README-IC-EN.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>A clean desktop app for batch renaming and converting images - fast, safe filenames, and predictable results.</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  

--- a/README/README-IC-RU.md
+++ b/README/README-IC-RU.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>Приложение для пакетного переименования и конвертации изображений - быстро, с безопасными именами файлов и предсказуемым результатом.</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  

--- a/README/README-IC-VN.md
+++ b/README/README-IC-VN.md
@@ -5,9 +5,9 @@
 <h2>Image Converter</h2>
 <p>Một ứng dụng desktop gọn gàng để đổi tên và chuyển đổi hình ảnh hàng loạt - nhanh chóng, tên tệp an toàn và kết quả ổn định.</p>
   <p>
-    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-    <img src="https://img.shields.io/badge/Python-3.13-blue.svg" alt="Python 3.13">
-    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release" alt="Latest release"></a>
+    <a href="https://github.com/nondeletable/Image-Converter/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-805a96.svg" alt="License: MIT"></a>
+    <img src="https://img.shields.io/badge/Python-3.13-805a96.svg" alt="Python 3.13">
+    <a href="https://github.com/nondeletable/Image-Converter/releases"><img src="https://img.shields.io/github/v/release/nondeletable/Image-Converter?label=release&color=805a96" alt="Latest release"></a>
   </p>
   <p>
     <a href="https://github.com/nondeletable/Image-Converter/tree/main/README/README-IC-EN.md">English </a> |  


### PR DESCRIPTION
Set License, Python and release badges to the app's lilac accent color across the main README and all five translations.